### PR TITLE
Remove additional text from worldboss names

### DIFF
--- a/RareTracker.lua
+++ b/RareTracker.lua
@@ -806,8 +806,14 @@ function RareTracker:InitRares()
     for _, achievement in pairs(arrAchievements) do
         if karrAchievements[achievement:GetId()] then
             for _,entry in pairs(achievement:GetChecklistItems()) do
-                table.insert(self.arRareNames, entry.strChecklistEntry)
-                self.achievementEntries[entry.strChecklistEntry] = entry.bIsComplete
+                local strChecklistEntry = entry.strChecklistEntry
+                --Remove "World Boss: " from worldboss names in all locales
+                if achievement:GetId() == 6797 then
+                    strChecklistEntry = string.gsub(strChecklistEntry, "^W[eo]r?l[dt]%s?", "")
+                    strChecklistEntry = string.gsub(strChecklistEntry, "^[bB]oss[^:]*:%s", "")
+                end
+                table.insert(self.arRareNames, strChecklistEntry)
+                self.achievementEntries[strChecklistEntry] = entry.bIsComplete
             end
         end
     end


### PR DESCRIPTION
Worldbosses have "World Boss: ", "Weltboss: "
or "Boss : " infront of their names that needs to
be removed.
